### PR TITLE
Fixing #29 - Team Path Separator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.checkmarx-ts</groupId>
 	<artifactId>cx-spring-boot-sdk</artifactId>
-	<version>0.4.8</version>
+	<version>0.4.9</version>
 	<name>cx-spring-boot-sdk</name>
 	<description>Checkmarx Java Spring Boot SDK</description>
 

--- a/src/main/java/com/checkmarx/sdk/config/CxProperties.java
+++ b/src/main/java/com/checkmarx/sdk/config/CxProperties.java
@@ -5,6 +5,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
+import javax.annotation.PostConstruct;
+
 
 @Component
 @ConfigurationProperties(prefix = "checkmarx")
@@ -407,6 +409,13 @@ public class CxProperties {
 
     public void setGitClonePath(String gitClonePath) {
         this.gitClonePath = gitClonePath;
+    }
+
+    @PostConstruct
+    private void initTeam(){
+        if(!team.startsWith(getTeamPathSeparator())){
+            this.team = getTeamPathSeparator().concat(this.team);
+        }
     }
 }
 


### PR DESCRIPTION
Fixing #29 - initialize the team property with the leading team path separator if missing.